### PR TITLE
Docker: upgrade PHP 7.1 to 7.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-SITE_NAME=mongobox
-#FIG=docker-compose --file /home/agiry/working-directory/dimipro/docker-compose.yml
+SITE_NAME=mongobox2
+#FIG=docker-compose --file ~/workspace/mongobox-sf4/docker-compose.yml
 
 FIG=docker-compose
 RUN_WEB=$(FIG) run --rm web
@@ -44,7 +44,7 @@ apache-restart:
 ##
 ## Shell for each docker container
 ##---------------------------------------------------------------------------
-web-shell:            ## Shell of  php 7.1
+web-shell:            ## Shell of  php 7.2
 web-shell:
 	-$(EXEC_WEB) /bin/bash
 
@@ -93,7 +93,7 @@ yarn-install:        ## Install node_modules
 yarn-install:
 	$(EXEC_NODEJS) /bin/bash -c "cd $(SITE_PATH) && yarn install"
 
-assets-compile-dev:         ## Compile assets for dev. Ex: make assets-compile-dev [CONFIG_NAME=dimipro|pulsat]
+assets-compile-dev:         ## Compile assets for dev. Ex: make assets-compile-dev
 assets-compile-dev:
 	$(EXEC_NODEJS) /bin/bash -c "cd $(SITE_PATH) && yarn run encore dev"
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-apache
+FROM php:7.2-apache
 
 MAINTAINER Aurélien GIRY <aurelien.giry@gmail.com>
 

--- a/docker/web/extra/vhosts/mongobox.conf
+++ b/docker/web/extra/vhosts/mongobox.conf
@@ -1,11 +1,11 @@
 <VirtualHost *:80>
-    ServerName mongobox-v2.local
-    ServerAlias www.mongobox-v2.local
+    ServerName mongobox.local
+    ServerAlias www.mongobox.local
 
     AddDefaultCharset UTF-8
-    DocumentRoot /var/www/mongobox2/public
+    DocumentRoot /var/www/mongobox/web
 
-    <Directory /var/www/mongobox2/public>
+    <Directory /var/www/mongobox/web>
         AllowOverride None
         Order Allow,Deny
         Allow from All
@@ -14,14 +14,13 @@
             Options -MultiViews
             RewriteEngine On
 
-            RewriteCond %{REQUEST_URI} !^/(bundles|css|flash|images|js)/
             RewriteCond %{REQUEST_FILENAME} !-f
-            RewriteRule ^(.*)$ index.php [QSA,L]
+            RewriteRule ^(.*)$ app_dev.php [QSA,L]
         </IfModule>
     </Directory>
 
-    ErrorLog /var/log/apache2/mongobox2_error.log
-    CustomLog /var/log/apache2/mongobox2_access.log combined
+    ErrorLog /var/log/apache2/mongobox_error.log
+    CustomLog /var/log/apache2/mongobox_access.log combined
 
     <IfModule mod_deflate.c>
          SetOutputFilter DEFLATE


### PR DESCRIPTION
Changes proposed in this pull request:
- upgrade docker web container :  php:7.1-apache  => php:7.2-apache
- add vhosts for Mongobox 1 and Mongobox 2
- update Makefile
